### PR TITLE
fix: inconsistent error handling for name encoding.

### DIFF
--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -2,10 +2,10 @@ declare var BLOCKFROST_PROJECT_ID: string;
 import { Buffer } from 'buffer';
 import { FC, useCallback, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import HandleClient, { HandleClientContext, HandleClientProvider, KoraLabsProvider } from '../../lib';
+import HandleClient, { HandleClientContext, KoraLabsProvider } from '../../lib';
 import { BlockfrostHandle, BlockfrostProvider } from '../../lib/classes/providers/BlockfrostProvider.class';
 
-import { IHandle } from '@koralabs/handles-public-api-interfaces';
+import { AssetNameLabel, IHandle } from '@koralabs/handles-public-api-interfaces';
 import JSONView from 'react-json-view';
 
 const KoraInstance = new HandleClient({
@@ -29,9 +29,10 @@ const App: FC = () => {
         async (handle: string) => {
             setLoading(true);
 
-            const realHandle = (cip68 ? HandleClientProvider.CIP68_PREFIX : '') + Buffer.from(handle).toString('hex');
-            const blockfrostData = await BlockfrostInstance.provider().getAllData(realHandle);
-            const koraData = await KoraInstance.provider().getAllData(realHandle);
+            const realHandle =
+                (cip68 ? AssetNameLabel.LABEL_222 : '') + Buffer.from(handle.replace('$', '')).toString('hex');
+            const blockfrostData = await BlockfrostInstance.provider().getAllData({ value: realHandle });
+            const koraData = await KoraInstance.provider().getAllData({ value: realHandle });
 
             setLoading(false);
             blockfrostData && setBlockfrostResult(blockfrostData);

--- a/demo/webpack.config.cjs
+++ b/demo/webpack.config.cjs
@@ -65,6 +65,9 @@ module.exports = {
         new webpack.DefinePlugin({
             'BLOCKFROST_PROJECT_ID': JSON.stringify(env.BLOCKFROST_PROJECT_ID),
         }),
+        new webpack.ProvidePlugin({
+            Buffer: ["buffer", "Buffer"]
+        }),
         new HtmlWebpackPlugin({
             template: './src/index.html',
             filename: 'index.html',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@koralabs/adahandle-sdk",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "SDK for ADA Handle",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/src/__tests__/HandleClient.test.ts
+++ b/src/__tests__/HandleClient.test.ts
@@ -1,7 +1,7 @@
 import { AssetNameLabel } from '@koralabs/handles-public-api-interfaces';
 import { HandleClient } from '../classes/HandleClient.class';
 import { HandleClientProvider, KoraLabsProvider } from '../classes/providers';
-import { HandleClientContext, HandleClientOptions } from '../types';
+import { HEX, HandleClientContext, HandleClientOptions } from '../types';
 
 let client: HandleClient;
 
@@ -10,25 +10,25 @@ class CustomProvider extends HandleClientProvider {
         super();
     }
 
-    getCardanoAddress = async (handle: string) => {
+    getCardanoAddress = async (handle: HEX) => {
         return new Promise<string>((res) => {
             setTimeout(() => res('cardanoaddress'), 1000);
         });
     };
 
-    getBitcoinAddress = async (handle: string) => {
+    getBitcoinAddress = async (handle: HEX) => {
         return new Promise<string>((res) => {
             setTimeout(() => res('bitcoinaddress'), 1000);
         });
     };
 
-    getEthereumAddress = async (handle: string) => {
+    getEthereumAddress = async (handle: HEX) => {
         return new Promise<string>((res) => {
             setTimeout(() => res('ethereumaddress'), 1000);
         });
     };
 
-    getAllData = async (handle: string) => {
+    getAllData = async (handle: HEX) => {
         return new Promise<Record<string, string>>((res) => {
             setTimeout(
                 () =>
@@ -109,26 +109,34 @@ describe('HandleClient', () => {
 
         const provider = customClient.provider();
         expect(provider).toBeInstanceOf(CustomProvider);
-        expect(await provider.getCardanoAddress('myhandle')).toEqual('cardanoaddress');
-        expect(await provider.getBitcoinAddress('myhandle')).toEqual('bitcoinaddress');
-        expect(await provider.getEthereumAddress('myhandle')).toEqual('ethereumaddress');
-        expect(await provider.getAllData('myhandle')).toMatchObject({
+        expect(await provider.getCardanoAddress({ value: 'myhandle' })).toEqual('cardanoaddress');
+        expect(await provider.getBitcoinAddress({ value: 'myhandle' })).toEqual('bitcoinaddress');
+        expect(await provider.getEthereumAddress({ value: 'myhandle' })).toEqual('ethereumaddress');
+        expect(await provider.getAllData({ value: 'myhandle' })).toMatchObject({
             name: 'customdata'
         });
     });
 
     test('isCIP68', () => {
-        expect(HandleClient.isCIP68('000de140706f707a')).toBeTruthy();
-        expect(HandleClient.isCIP68('63616c76696e')).toBeFalsy();
+        expect(HandleClient.isCIP68({ value: '000de140706f707a' })).toBeTruthy();
+        expect(HandleClient.isCIP68({ value: '63616c76696e' })).toBeFalsy();
     });
 
     test('getNormalizedName', () => {
-        expect(HandleClient.getNormalizedName('000de140706f707a')).toEqual('popz');
-        expect(HandleClient.getNormalizedName('63616c76696e')).toEqual('calvin');
+        expect(HandleClient.getNormalizedName({ value: '000de140706f707a' })).toEqual({ value: 'popz' });
+        expect(HandleClient.getNormalizedName({ value: '63616c76696e' })).toEqual({ value: 'calvin' });
+        expect(() => HandleClient.getNormalizedName({ value: 'papagoose' })).toThrowError(
+            'To get a normalized name, you must provide a valid HEX encoded name.'
+        );
+        expect(() => HandleClient.getNormalizedName({ value: '' })).toThrowError(
+            'To get a normalized name, you must provide a valid HEX encoded name.'
+        );
     });
 
     test('getEncodedName', () => {
-        expect(HandleClient.getEncodedName('popz', AssetNameLabel.LABEL_222)).toEqual('000de140706f707a');
-        expect(HandleClient.getEncodedName('calvin')).toEqual('63616c76696e');
+        expect(HandleClient.getEncodedName({ value: 'popz' }, AssetNameLabel.LABEL_222)).toEqual({
+            value: '000de140706f707a'
+        });
+        expect(HandleClient.getEncodedName({ value: 'calvin' })).toEqual({ value: '63616c76696e' });
     });
 });

--- a/src/classes/HandleClient.class.ts
+++ b/src/classes/HandleClient.class.ts
@@ -1,7 +1,7 @@
 import { AssetNameLabel } from '@koralabs/handles-public-api-interfaces';
-import { HandleClientContext, HandleClientOptions } from '../types';
-import { isHex } from '../utils/hex';
+import { HEX, HandleClientContext, HandleClientOptions, Readable } from '../types';
 import { KoraLabsProvider } from './providers/KoraLabsProvider.class';
+import { isHex } from '../utils/hex';
 
 export class HandleClient<T = KoraLabsProvider> {
     private options: HandleClientOptions<T>;
@@ -42,34 +42,42 @@ export class HandleClient<T = KoraLabsProvider> {
     /**
      * Utility method to check whether a handle is a CIP-68 handle.
      *
-     * @param {string} handle - The handle to check in its HEX encoded format.
+     * @param {HEX} handle - The handle to check in its HEX encoded format.
      * @returns {boolean} - Whether the handle is CIP-68 or not.
      * @throws
      */
-    static isCIP68(handle: string): boolean {
-        return handle.indexOf(AssetNameLabel.LABEL_222) === 0;
+    static isCIP68(handle: HEX): boolean {
+        return handle.value.indexOf(AssetNameLabel.LABEL_222) === 0;
     }
 
     /**
      * Utility method to get the normalized name of a CIP-68 or CIP-25 handle.
      *
-     * @param {string} handle - The CIP-68 or CIP-25 handle to parse, in HEX format.
-     * @returns {string}
+     * @param {HEX} handle - The CIP-68 or CIP-25 handle to parse, in HEX format.
+     * @returns {Readable}
+     * @throws
      */
-    static getNormalizedName(handle: string): string {
-        const hexName = HandleClient.isCIP68(handle) ? handle.replace(AssetNameLabel.LABEL_222, '') : handle;
-        return Buffer.from(hexName, 'hex').toString('utf-8');
+    static getNormalizedName(handle: HEX): Readable {
+        if (!isHex(handle.value) || handle.value === '') {
+            throw new Error('To get a normalized name, you must provide a valid HEX encoded name.');
+        }
+
+        const hexName = HandleClient.isCIP68(handle)
+            ? handle.value.replace(AssetNameLabel.LABEL_222, '')
+            : handle.value;
+
+        return { value: Buffer.from(hexName, 'hex').toString('utf-8') };
     }
 
     /**
      * Utility method to get the HEX-encoded name of the CIP-68 or CIP-25 handle.
      *
-     * @param {string} handle - The CIP-68 or CIP-25 handle to parse, in UTF-8 format.
-     * @returns {string}
+     * @param {Readable} handle - The CIP-68 or CIP-25 handle to parse, in UTF-8 format.
+     * @returns {HEX}
      * @throws
      */
-    static getEncodedName(handle: string, assetNameLabel?: AssetNameLabel): string {
-        const name = Buffer.from(handle).toString('hex');
-        return assetNameLabel ? `${assetNameLabel}${name}` : name;
+    static getEncodedName(handle: HEX, assetNameLabel?: AssetNameLabel): HEX {
+        const name = Buffer.from(handle.value).toString('hex');
+        return { value: assetNameLabel ? `${assetNameLabel}${name}` : name };
     }
 }

--- a/src/classes/providers/BlockfrostProvider.class.ts
+++ b/src/classes/providers/BlockfrostProvider.class.ts
@@ -4,7 +4,7 @@ import type { components } from '@blockfrost/openapi';
 
 import { HandleClient } from '../HandleClient.class';
 import { HandleClientProvider } from './HandleClientProvider.abstract.class';
-import { HandleClientContext } from '../../types';
+import { HEX, HandleClientContext } from '../../types';
 
 export type BlockfrostHandle =
     | ((components['schemas']['onchain_metadata_cip25'] | components['schemas']['onchain_metadata_cip68_nft_222']) & {
@@ -43,10 +43,10 @@ export class BlockfrostProvider extends HandleClientProvider<BlockfrostHandle> {
     /**
      * Retrieves the Cardano address for a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup.
      * @returns {Promise<string>} - A promise that resolves to the Cardano address.
      */
-    getCardanoAddress = async (handle: string): Promise<string> => {
+    getCardanoAddress = async (handle: HEX): Promise<string> => {
         if (HandleClient.isCIP68(handle)) {
             const { onchain_metadata } = await this.__handleResponse<BlockfrostHandle>(
                 fetch(
@@ -81,20 +81,15 @@ export class BlockfrostProvider extends HandleClientProvider<BlockfrostHandle> {
     /**
      * Retrieves the Bitcoin address for a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup.
      * @returns {Promise<string|undefined>} - A promise that resolves to the Bitcoin address, or undefined if not found.
      */
-    getBitcoinAddress = async (handle: string): Promise<string | undefined> => {
+    getBitcoinAddress = async (handle: HEX): Promise<string | undefined> => {
         if (HandleClient.isCIP68(handle)) {
             const { onchain_metadata } = await this.__handleResponse<BlockfrostHandle>(
-                fetch(
-                    `${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${HandleClient.getEncodedName(
-                        handle
-                    )}`,
-                    {
-                        headers: this.headers
-                    }
-                ),
+                fetch(`${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${handle.value}`, {
+                    headers: this.headers
+                }),
                 HandleClient.getNormalizedName(handle)
             );
 
@@ -109,20 +104,15 @@ export class BlockfrostProvider extends HandleClientProvider<BlockfrostHandle> {
     /**
      * Retrieves the Ethereum address for a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup.
      * @returns {Promise<string|undefined>} - A promise that resolves to the Ethereum address, or undefined if not found.
      */
-    getEthereumAddress = async (handle: string): Promise<string | undefined> => {
+    getEthereumAddress = async (handle: HEX): Promise<string | undefined> => {
         if (HandleClient.isCIP68(handle)) {
             const { onchain_metadata } = await this.__handleResponse<BlockfrostHandle>(
-                fetch(
-                    `${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${HandleClient.getEncodedName(
-                        handle
-                    )}`,
-                    {
-                        headers: this.headers
-                    }
-                ),
+                fetch(`${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${handle.value}`, {
+                    headers: this.headers
+                }),
                 HandleClient.getNormalizedName(handle)
             );
 
@@ -137,19 +127,14 @@ export class BlockfrostProvider extends HandleClientProvider<BlockfrostHandle> {
     /**
      * Retrieves all data associated with a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup.
      * @returns {Promise<BlockfrostHandle | IHandle>} - A promise that resolves to the handle data.
      */
-    getAllData = async (handle: string): Promise<BlockfrostHandle> => {
+    getAllData = async (handle: HEX): Promise<BlockfrostHandle> => {
         const data = await this.__handleResponse<BlockfrostHandle>(
-            fetch(
-                `${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${HandleClient.getEncodedName(
-                    handle
-                )}`,
-                {
-                    headers: this.headers
-                }
-            ),
+            fetch(`${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${handle.value}`, {
+                headers: this.headers
+            }),
             HandleClient.getNormalizedName(handle)
         );
 
@@ -160,12 +145,9 @@ export class BlockfrostProvider extends HandleClientProvider<BlockfrostHandle> {
 
         if (!result?.resolved_addresses) {
             const addresses = await this.__handleResponse<components['schemas']['asset_addresses']>(
-                fetch(
-                    `${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${HandleClient.getEncodedName(
-                        handle
-                    )}/addresses`,
-                    { headers: this.headers }
-                ),
+                fetch(`${this.apiUrl}/assets/${HandleClient.policyIds[this.network][0]}${handle.value}/addresses`, {
+                    headers: this.headers
+                }),
                 HandleClient.getNormalizedName(handle)
             );
             result.address = addresses?.[0]?.address;

--- a/src/classes/providers/HandleClientProvider.abstract.class.ts
+++ b/src/classes/providers/HandleClientProvider.abstract.class.ts
@@ -1,8 +1,5 @@
-import { Buffer } from 'buffer';
-import { AssetNameLabel } from '@koralabs/handles-public-api-interfaces';
-
 import { isHex } from '../../utils/hex';
-import { HandleClient } from '../HandleClient.class';
+import { HEX, Readable } from '../../types';
 
 /**
  * Abstract class `HandleClientProvider` serving as a template for
@@ -15,51 +12,51 @@ export abstract class HandleClientProvider<T = {}> {
      * Abstract method to retrieve the Cardano address for a given handle.
      *
      * @abstract
-     * @param {string} handle - The handle to look up.
+     * @param {HEX} handle - The handle to look up.
      * @returns {Promise<string>} - A promise that resolves to the Cardano address.
      */
-    abstract getCardanoAddress: (handle: string) => Promise<string>;
+    abstract getCardanoAddress: (handle: HEX) => Promise<string>;
 
     /**
      * Abstract method to retrieve the Bitcoin address for a given handle.
      *
      * @abstract
-     * @param {string} handle - The handle to look up.
+     * @param {HEX} handle - The handle to look up.
      * @returns {Promise<string|undefined>} - A promise that resolves to the Bitcoin address or undefined if not found.
      */
-    abstract getBitcoinAddress: (handle: string) => Promise<string | undefined>;
+    abstract getBitcoinAddress: (handle: HEX) => Promise<string | undefined>;
 
     /**
      * Abstract method to retrieve the Ethereum address for a given handle.
      *
      * @abstract
-     * @param {string} handle - The handle to look up.
+     * @param {HEX} handle - The handle to look up.
      * @returns {Promise<string|undefined>} - A promise that resolves to the Ethereum address or undefined if not found.
      */
-    abstract getEthereumAddress: (handle: string) => Promise<string | undefined>;
+    abstract getEthereumAddress: (handle: HEX) => Promise<string | undefined>;
 
     /**
      * Abstract method to retrieve all data associated with a given handle.
      *
      * @abstract
-     * @param {string} handle - The handle to look up.
+     * @param {HEX} handle - The handle to look up.
      * @returns {Promise<T>} - A promise that resolves to the handle data.
      */
-    abstract getAllData: (handle: string) => Promise<T>;
+    abstract getAllData: (handle: HEX) => Promise<T>;
 
     /**
      * Handles API rejection feedback for handle-specific requests.
      * @param {Promise<Response>} api - The API response, usually from fetch().
-     * @param {string} handle - The handle supplied to the lookup.
+     * @param {HEX} handle - The handle supplied to the lookup.
      * @returns
      */
-    protected async __handleResponse<T>(api: Promise<Response>, handle: string) {
+    protected async __handleResponse<T>(api: Promise<Response>, handle: Readable) {
         return api
             .then((res) => res.json() as T)
             .catch((e) => {
                 console.error(
-                    `Something went wrong while fetching this Handle: ${handle}.${
-                        isHex(handle)
+                    `Something went wrong while fetching this Handle: ${handle.value}.${
+                        isHex(handle.value)
                             ? ` You may need to convert the Handle name to UTF-8 before providing it to this function.`
                             : ''
                     } Here is the full error:`,

--- a/src/classes/providers/KoraLabsProvider.class.ts
+++ b/src/classes/providers/KoraLabsProvider.class.ts
@@ -3,7 +3,7 @@ import fetch from 'cross-fetch';
 
 import { HandleClient } from '../HandleClient.class';
 import { HandleClientProvider } from './HandleClientProvider.abstract.class';
-import { HandleClientContext } from '../../types';
+import { HEX, HandleClientContext } from '../../types';
 
 /**
  * KoraLabsProvider class that extends HandleClientProvider and
@@ -38,13 +38,13 @@ export class KoraLabsProvider extends HandleClientProvider<IHandle> {
     /**
      * Retrieves the Cardano address for a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup, in HEX format.
      * @returns {Promise<string>} - A promise that resolves to the Cardano address.
      */
-    getCardanoAddress = async (handle: string): Promise<string> => {
+    getCardanoAddress = async (handle: HEX): Promise<string> => {
         const name = HandleClient.getNormalizedName(handle);
         const { resolved_addresses } = await this.__handleResponse<IHandle>(
-            fetch(`${this.apiUrl}/handles/${name}`, {
+            fetch(`${this.apiUrl}/handles/${name.value}`, {
                 headers: this.headers
             }),
             name
@@ -55,13 +55,13 @@ export class KoraLabsProvider extends HandleClientProvider<IHandle> {
     /**
      * Retrieves the Bitcoin address for a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup, in HEX format.
      * @returns {Promise<string|undefined>} - A promise that resolves to the Bitcoin address, or undefined if not found.
      */
-    getBitcoinAddress = async (handle: string): Promise<string | undefined> => {
+    getBitcoinAddress = async (handle: HEX): Promise<string | undefined> => {
         const name = HandleClient.getNormalizedName(handle);
         const { resolved_addresses } = await this.__handleResponse<IHandle>(
-            fetch(`${this.apiUrl}/handles/${name}`, {
+            fetch(`${this.apiUrl}/handles/${name.value}`, {
                 headers: this.headers
             }),
             name
@@ -72,13 +72,13 @@ export class KoraLabsProvider extends HandleClientProvider<IHandle> {
     /**
      * Retrieves the Ethereum address for a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup, in HEX format.
      * @returns {Promise<string|undefined>} - A promise that resolves to the Ethereum address, or undefined if not found.
      */
-    getEthereumAddress = async (handle: string): Promise<string | undefined> => {
+    getEthereumAddress = async (handle: HEX): Promise<string | undefined> => {
         const name = HandleClient.getNormalizedName(handle);
         const { resolved_addresses } = await this.__handleResponse<IHandle>(
-            fetch(`${this.apiUrl}/handles/${name}`, {
+            fetch(`${this.apiUrl}/handles/${name.value}`, {
                 headers: this.headers
             }),
             name
@@ -89,13 +89,13 @@ export class KoraLabsProvider extends HandleClientProvider<IHandle> {
     /**
      * Retrieves all data associated with a given handle.
      *
-     * @param {string} handle - The handle to lookup.
+     * @param {HEX} handle - The handle to lookup, in HEX format.
      * @returns {Promise<IHandle>} - A promise that resolves to the handle data.
      */
-    getAllData = async (handle: string): Promise<IHandle> => {
+    getAllData = async (handle: HEX): Promise<IHandle> => {
         const name = HandleClient.getNormalizedName(handle);
         return this.__handleResponse<IHandle>(
-            fetch(`${this.apiUrl}/handles/${name}`, {
+            fetch(`${this.apiUrl}/handles/${name.value}`, {
                 headers: this.headers
             }),
             name

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,11 @@
-import { HandleClientProvider, KoraLabsProvider } from './classes/providers';
+import { HandleClientProvider } from './classes/providers';
+
+export interface HEX {
+    value: string;
+}
+export interface Readable {
+    value: string;
+}
 
 export enum HandleClientContext {
     PREVIEW = 0,


### PR DESCRIPTION
This adds a few catches for edge-case scenarios:

- Invalid encoding of handle names.
- Error handling for those.
- Custom types to make the required Handle encoding more obvious for clients.