### PR TITLE
chore: support named exports for better esm support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { IHandle } from '@koralabs/handles-public-api-interfaces';
+export { HandleClient as default } from './classes/HandleClient.class';
 export * from './classes/HandleClient.class';
 export * from './classes/providers';
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { IHandle } from '@koralabs/handles-public-api-interfaces';
-export { HandleClient as default } from './classes/HandleClient.class';
+export * from './classes/HandleClient.class';
 export * from './classes/providers';
 export * from './types';


### PR DESCRIPTION
Compatibility issues with bundlers when mixing default and named exports.